### PR TITLE
Fix/helm docs

### DIFF
--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -4,16 +4,17 @@ on:
   push:
     branches:
       - master
-    paths:
-      - 'charts/helmchart/**'
-      - 'charts/cronjob/**'
-
+      - fix/helm-docs
+    # paths:
+    #   - 'charts/helmchart/**'
+    #   - 'charts/cronjob/**'
+    
 jobs:
   install-helm-docs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Helm Docs
-      uses: envoy/install-helm-docs
+      uses: envoy/install-helm-docs@v1.0.0
       with:
         # Helm Docs Version to install (Mandatory)
-        helm_docs_version: 1.8.0
+        helm_docs_version: 1.7.0

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -4,10 +4,9 @@ on:
   push:
     branches:
       - master
-      - fix/helm-docs
-    # paths:
-    #   - 'charts/helmchart/**'
-    #   - 'charts/cronjob/**'
+    paths:
+      - 'charts/helmchart/**'
+      - 'charts/cronjob/**'
     
 jobs:
   install-helm-docs:


### PR DESCRIPTION
## what
- Helm Docs github action `uses` and `version` attributes

## why
- `uses` was giving error that `uses attribute must be a path, a Docker image, or owner/repo@ref`
- the latest version available for `envoy/install-helm-docs@v1.0.0` GitHub Action is `1.7.0` as per the GitHub Repository(https://github.com/envoy/install-helm-docs)