### PR TITLE
Fix: condition to controll Gateway creation and selector for istio service

### DIFF
--- a/charts/helmchart/templates/gateway.yaml
+++ b/charts/helmchart/templates/gateway.yaml
@@ -1,11 +1,13 @@
 {{- if .Values.istio.enabled -}}
+{{- if .Values.istio.gateway.enabled -}}
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: {{ include "helmchart.fullname" . }}-istio-gateway
+  namespace: {{ default .Release.Namespace .Values.istio.gateway.namespace }}
 spec:
   selector:
-    istio: ingress
+    istio: {{ .Values.istio.gateway.selector }}
   servers:
   - hosts:
     {{- range .Values.istio.virtualService.hosts }}
@@ -15,4 +17,5 @@ spec:
       number: {{ .Values.service.port }}
       name: http
       protocol: HTTP
+{{- end }}
 {{- end }}

--- a/charts/helmchart/templates/virtualservice.yaml
+++ b/charts/helmchart/templates/virtualservice.yaml
@@ -11,9 +11,13 @@ spec:
     - {{ . | quote }}
     {{- end }} 
   gateways:
+    {{- if .Values.istio.gateway.enabled }}
+    - {{ default .Release.Namespace .Values.istio.gateway.namespace }}/{{ include "helmchart.fullname" . }}-istio-gateway
+    {{- else }}  
     {{- range .Values.istio.gateway.names }}
     - {{ . }}
-    {{- end }} 
+    {{- end }}
+    {{- end }}     
   http:
   - route:
     - destination:

--- a/charts/helmchart/values.yaml
+++ b/charts/helmchart/values.yaml
@@ -56,7 +56,7 @@ securityContext: {}
 
 service: 
     # -- service is a map that specifies the  configuration for the Service resource that is created by the chart.
-  enabled: false
+  enabled: true
     # -- Specifies whether a service should be created.        
   type: ClusterIP 
     # -- The Service type,  as defined in Kubernetes. Defaults to ClusterIP.
@@ -64,17 +64,27 @@ service:
     # -- A map that specifies the port bindings of the service against the Pods in the Deployment.
 
 istio:
-  # -- We can either use Istio or Ingress for an application deployment.
-  enabled: false
+  # -- We can either use Istio or Ingress for an application deployment. Set `enabled: true` if istio is already installed.
+  enabled: true
   # -- virtualService is required when using istio.
   virtualService:
-    hosts: []
+    # hosts: []
+    hosts: 
       # - test.example.com
       # - test-2.example.com
-  # -- 
+  
   gateway:
+    # -- Set `enabled: true` to install Gateway for istio using this helmchart.
+    enabled: false
+    
+    # -- Provide name of namespace where your istio is installed. Gateway and Istio has to be in same namespace.
+    namespace: "istio-system"
+    
+    # -- Provide name of istio gateways here, this option is only applicable when istio gateway is already present in kubernetes cluster and not being managed by this helmchart.
     names: 
       - "istio-system/istio-gateway"
+    # -- Provide selector for istio gateway to select istio service.
+    selector: "ingress"
 
 ingress:    
     # -- ingress is a map that can be used to configure an Ingress resource for this service.


### PR DESCRIPTION
### what 
- `if` condition to controll `kind: Gateway` creation.
- Update VirtualService gateway field If Gateway is created using helmchart.
- User defined selector for Gateway to select istio service.
- Update comments in values.yaml for better clarification.