### PR TITLE
feat: user defined ports and healthcheck-probes

### DIFF
--- a/charts/helmchart/config/override-values.yaml
+++ b/charts/helmchart/config/override-values.yaml
@@ -57,6 +57,7 @@ service:
 istio:
   enabled: false
   virtualService:
+    enabled: true
     hosts: 
       - test.example.com
       - test-2.example.com
@@ -73,7 +74,6 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-
   tls: []
 
 resource:

--- a/charts/helmchart/config/override-values.yaml
+++ b/charts/helmchart/config/override-values.yaml
@@ -49,9 +49,10 @@ securityContext:
 
 service: 
   enabled: true
-  # type: ClusterIP 
   type: NodePort 
-  port: 80   
+  port: 80  
+  containerPort: 80
+  targetPort: http
 
 istio:
   enabled: false
@@ -77,10 +78,10 @@ ingress:
 
 resource:
   enabled: true
-resources:
+resources: 
   limits:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 200m
+    memory: 512Mi
   requests:
     cpu: 100m
     memory: 128Mi
@@ -153,14 +154,3 @@ storageClass:
 
 statefulSets:
   enabled: false
-
-healthCheckProbes:
-  enabled: true
-  livenessProbe:
-    httpGet:
-      path: /
-      port: http
-  readinessProbe:
-    httpGet:
-      path: /
-      port: http

--- a/charts/helmchart/templates/deployment.yaml
+++ b/charts/helmchart/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.service.containerPort | default .Values.service.port }}
               protocol: TCP
           envFrom:
           {{- if .Values.configmap.enabled }}
@@ -53,14 +53,7 @@ spec:
                 name: {{ include "helmchart.fullname" . }}-secret
           {{- end }}
           {{- if .Values.healthCheckProbes.enabled }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.healthCheckProbes.livenessProbe.httpGet.path }}
-              port: {{ .Values.healthCheckProbes.livenessProbe.httpGet.port }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.healthCheckProbes.readinessProbe.httpGet.path }}
-              port: {{ .Values.healthCheckProbes.readinessProbe.httpGet.port }}
+          {{- toYaml .Values.healthCheckProbes.probes | nindent 10 }}
           {{- end }}
           {{- if .Values.resource.enabled }}
           resources:

--- a/charts/helmchart/templates/service.yaml
+++ b/charts/helmchart/templates/service.yaml
@@ -10,7 +10,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort | default "http" }}
       protocol: TCP
       name: http
   selector:

--- a/charts/helmchart/templates/servicemonitor.yaml
+++ b/charts/helmchart/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
-# This object requires CustomResourceDefinition (crds).
 {{- if .Values.metrics.enabled }}
+# This object requires CustomResourceDefinition (crds).
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/helmchart/templates/virtualservice.yaml
+++ b/charts/helmchart/templates/virtualservice.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.istio.enabled -}}
+{{- if .Values.istio.virtualService.enabled -}}
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:

--- a/charts/helmchart/values.schema.json
+++ b/charts/helmchart/values.schema.json
@@ -19,7 +19,6 @@
       "securityContext",
       "service",
       "ingress",
-      "resources",
       "autoscaling",
       "poddisruptionbudget",
       "nodeSelector",
@@ -291,72 +290,7 @@
             }
         }
     },
-    "resources": {
-      "type": "object",
-      "default": {},
-      "title": "The resources Schema",
-      "required": [
-          "limits",
-          "requests"
-      ],
-      "properties": {
-          "limits": {
-              "type": "object",
-              "default": {},
-              "title": "The limits Schema",
-              "required": [
-                  "cpu",
-                  "memory"
-              ],
-              "properties": {
-                  "cpu": {
-                      "type": "string",
-                      "default": "",
-                      "title": "The cpu Schema",
-                      "examples": [
-                          "100m"
-                      ]
-                  },
-                  "memory": {
-                      "type": "string",
-                      "default": "",
-                      "title": "The memory Schema",
-                      "examples": [
-                          "128Mi"
-                      ]
-                  }
-              }
-          },
-          "requests": {
-              "type": "object",
-              "default": {},
-              "title": "The requests Schema",
-              "required": [
-                  "cpu",
-                  "memory"
-              ],
-              "properties": {
-                  "cpu": {
-                      "type": "string",
-                      "default": "",
-                      "title": "The cpu Schema",
-                      "examples": [
-                          "100m"
-                      ]
-                  },
-                  "memory": {
-                      "type": "string",
-                      "default": "",
-                      "title": "The memory Schema",
-                      "examples": [
-                          "128Mi"
-                      ]
-                  }
-              }
-          }
-      }
-      },
-      "autoscaling": {
+    "autoscaling": {
         "type": "object",
         "default": {},
         "title": "The autoscaling Schema",

--- a/charts/helmchart/values.yaml
+++ b/charts/helmchart/values.yaml
@@ -73,6 +73,7 @@ istio:
   enabled: false
   # -- virtualService is required when using istio.
   virtualService:
+    enabled: false
     hosts: []
       # - test.example.com
       # - test-2.example.com

--- a/charts/helmchart/values.yaml
+++ b/charts/helmchart/values.yaml
@@ -16,25 +16,26 @@ image:
       # -- Specify digest of image. Tags can be overriden but each tag will contain different digest than previous.
   digest: ""
 
+imagePullSecrets: [] 
+  # -- imagePullSecrets lists the Secret resources that should be used for accessing private registries.
+
 secret:
   enabled: false 
     # -- secrets is a map that specifies the Secret resources that should be exposed to the main application container.           
-  secrets:
-    KEY: "value"
+  secrets: {}
+    # KEY: "value"
 
 configmap:
   enabled: false
-  configs:
-    KEY: "value"
+  configs: {}
+    # KEY: "value"
 
-imagePullSecrets: [] 
-  # -- imagePullSecrets lists the Secret resources that should be used for accessing private registries.
 nameOverride: "" 
 
 fullnameOverride: "" 
   # -- fullnameOverride is a string that allows overriding the default fullname that appears as the application name and is used as the application name by kubernetes.
 
-pdbMinAvailable: 30% 
+pdbMinAvailable: ""
   # -- minPodsAvailable specifies the minimum number of pods that should be available at any given point in time.
 
 serviceAccount:
@@ -61,15 +62,18 @@ service:
   type: ClusterIP 
     # -- The Service type,  as defined in Kubernetes. Defaults to ClusterIP.
   port: 80   
-    # -- A map that specifies the port bindings of the service against the Pods in the Deployment.
+    # -- port: on which the kubernetes service is exposed
+  containerPort: ""
+    # -- Port number on which the container is accepting traffic.
+  targetPort: ""
+    # -- Port number on which the pod is accepting traffic.
 
 istio:
   # -- We can either use Istio or Ingress for an application deployment. Set `enabled: true` if istio is already installed.
-  enabled: true
+  enabled: false
   # -- virtualService is required when using istio.
   virtualService:
-    # hosts: []
-    hosts: 
+    hosts: []
       # - test.example.com
       # - test-2.example.com
   
@@ -110,14 +114,14 @@ ingress:
 
 resource: 
   enabled: false
-resources: 
+resources: {}
   # -- Requests and Limits to be specified for each pod.
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+  # limits: 
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests: 
+  #   cpu: 100m
+  #   memory: 128Mi
 
 autoscaling:      
   enabled: false 
@@ -229,11 +233,24 @@ storageClass:
 healthCheckProbes:
   # -- liveness and readiness probes in deployment
   enabled: false
-  livenessProbe:
-    httpGet:
-      path: /
-      port: http
-  readinessProbe:
-    httpGet:
-      path: /
-      port: http
+  probes: {}
+    # livenessProbe:
+    #   failureThreshold: 3
+    #   httpGet:
+    #     path: /healthcheck
+    #     port: 80
+    #     scheme: HTTP
+    #   initialDelaySeconds: 60
+    #   periodSeconds: 10
+    #   successThreshold: 1
+    #   timeoutSeconds: 2
+    # readinessProbe:
+    #   failureThreshold: 3
+    #   httpGet:
+    #     path: /healthcheck
+    #     port: 80
+    #     scheme: HTTP
+    #   initialDelaySeconds: 60
+    #   periodSeconds: 10
+    #   successThreshold: 1
+    #   timeoutSeconds: 2      


### PR DESCRIPTION
## What
- User can define their own
  - `containerPort:` & `targetPort:` if user does not provide any values then a default value will be used
  - `livenessProbe` & `readinessProbe` 

- Removed condition that makes passing `resources: limit & request` mandatory.
- Removed default `KEY: "VALUE"` pair from Secret & ConfigMap.
- Updated condition to control `VirtualService` creation.
- Updated `ServiceMonitor` yaml to fix below warning comes after successful chart installation.
```bash
## [warning]Capturing deployment metadata failed with error: TypeError: Cannot read property 'kind' of null
```