### PR TITLE
feat: add deployment strategy for RollingUpdate and Recreate

### DIFF
--- a/charts/helmchart/config/override-values.yaml
+++ b/charts/helmchart/config/override-values.yaml
@@ -3,8 +3,8 @@ replicaCount: 1
 image:
   repository: nginx
   pullPolicy: IfNotPresent
-  tag: "stable-alpine3.17"
-  digest: "sha256:5e1ccef1e821253829e415ac1e3eafe46920aab0bf67e0fe8a104c57dbfffdf7"
+  tag: "latest"
+  digest: "sha256:09369da6b10306312cd908661320086bf87fbae1b6b0c49a1f50ba531fef2eab"
 
 secret:
   enabled: true
@@ -21,7 +21,7 @@ imagePullSecrets: []
 commands:
   - /bin/sh
   - -c
-  - echo "Hello, from CloudDrove!"
+  - echo "Hello, from CloudDrove!"; nginx -g 'daemon off;'
 
 nameOverride: "" 
 
@@ -62,7 +62,7 @@ service:
 istio:
   enabled: false
   virtualService:
-    enabled: true
+    enabled: false
     hosts: 
       - test.example.com
       - test-2.example.com
@@ -72,12 +72,16 @@ istio:
 
 ingress:    
   enabled: true 
-  className: ""
-  annotations: {}
+  className: "alb"
+  annotations:
+    alb.ingress.kubernetes.io/group.name: ingress
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
   hosts:                        
     - host: chart-example.local
       paths:
-        - path: /
+        - path: /*
           pathType: ImplementationSpecific
   tls: []
 
@@ -172,3 +176,6 @@ storageClass:
 
 statefulSets:
   enabled: false
+
+deploymentStrategy:
+  type: Recreate

--- a/charts/helmchart/templates/deployment.yaml
+++ b/charts/helmchart/templates/deployment.yaml
@@ -9,6 +9,12 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if .Values.deploymentStrategy }}
+  strategy:
+  {{- with .Values.deploymentStrategy }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "helmchart.selectorLabels" . | nindent 6 }}

--- a/charts/helmchart/values.yaml
+++ b/charts/helmchart/values.yaml
@@ -102,7 +102,6 @@ ingress:
     # -- Specifies whether a ingress should be created
   className: ""
   annotations: {}
-        # -- Annotations that should be added to the Service resource. This is injected directly in to the resource yaml.
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:                        
@@ -240,6 +239,35 @@ healthCheckProbes:
   # -- liveness and readiness probes in deployment
   enabled: false
   probes: {}
-podLabels: 
-  ManagedBy: Clouddrove
-  
+    # livenessProbe:
+    #   enabled: true
+    #   httpGet:
+    #     path: /healthz
+    #     port: http
+    #   initialDelaySeconds: 10
+    #   periodSeconds: 10
+    #   timeoutSeconds: 2
+    #   failureThreshold: 3
+    #   successThreshold: 1
+    #
+    # readinessProbe:
+    #   enabled: true
+    #   httpGet:
+    #     path: /readyz
+    #     port: http
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 5
+    #   timeoutSeconds: 2
+    #   failureThreshold: 3
+    #   successThreshold: 1
+
+podLabels: {}
+  # -- podLabels allows you to add custom labels to the pods.
+  # ManagedBy: Clouddrove
+
+deploymentStrategy: {}
+  # -- Defines how updates to the Deployment are rolled out.
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 25%
+  #   maxUnavailable: 25%


### PR DESCRIPTION
## what
- Deployment strategy to support `RollingUpdate` and `Recreate`
- RollingUpdate
	```yaml
	strategy:
	  type: RollingUpdate
	  rollingUpdate:
		maxSurge: 1          # Extra Pods allowed above desired count during update
		maxUnavailable: 1    # Number of Pods allowed to be unavailable during update
	```
- Recreate
	```yaml
	strategy:
	  type: Recreate

	```