### PR TITLE
fix: (rbac) correct namespace uniqueness validation in _helpers.tpl

### DIFF
--- a/charts/rbac/templates/_helpers.tpl
+++ b/charts/rbac/templates/_helpers.tpl
@@ -10,10 +10,11 @@ Validate uniqueness of namespaces
 {{- if . }}
   {{- $seen := dict -}}
   {{- range $u := . }}
-    {{- if hasKey $seen $u.namespace | default (printf "ns-%s" $u.name) }}
-      {{- fail (printf "ERROR: >>>>>>> Duplicate namespace found: %s" $u.namespace) }}
+    {{- $ns := $u.namespace | default (printf "ns-%s" $u.name) }}
+    {{- if hasKey $seen $ns }}
+      {{- fail (printf "ERROR: >>>>>>> Duplicate namespace found: %s" $ns) }}
     {{- else }}
-      {{- $_ := set $seen $u.namespace true }}
+      {{- $_ := set $seen $ns true }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### What
- [charts/rbac] Fix namespace uniqueness validation in `_helpers.tpl` by applying default value before `hasKey`.

### Why
- Previous logic caused false duplicate errors **even with valid unique namespaces**. This fix ensures correct validation.