### PR TITLE
Update secret.yaml

### DIFF
--- a/charts/cloudflare-ddns/templates/secret.yaml
+++ b/charts/cloudflare-ddns/templates/secret.yaml
@@ -1,8 +1,8 @@
-{{- if not .Values.secret.name }}
+{{- if .Values.secret.value }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cloudflare-ddns.fullname" . }}
+  name: {{ default (include "cloudflare-ddns.fullname" .) .Values.secret.name }}
   labels:
     {{- include "cloudflare-ddns.labels" . | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
## what

**Previous Behaviour**

- deploying the cloudflare-ddns Helm chart with a secret.value provided in values.yaml or via --set-literal, the Kubernetes Secret was not being created. So the pod could not access the `CF_API_TOKEN` environment variable.

**Current Fix**
- Updated the templates/secret.yaml so that when secret.name is left empty, Helm will auto-create the Secret using the key and value provided. Now, deploying the chart with a secret.value successfully creates the Secret, mounts it to the pod, and the pod can access the `CF_API_TOKEN` environment variable.

**Expected output:**

- Secret ddns-updater-<chart-name> is created in the namespace.