### PR TITLE
feat: Add workload metadata annotations

### DIFF
--- a/charts/helmchart/templates/daemonset.yaml
+++ b/charts/helmchart/templates/daemonset.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- with .Values.daemonset.extraLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.daemonset.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/helmchart/templates/deployment.yaml
+++ b/charts/helmchart/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ include "helmchart.namespace" . }}
   labels:
     {{- include "helmchart.labels" . | nindent 4 }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/helmchart/templates/statefulset.yaml
+++ b/charts/helmchart/templates/statefulset.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- with .Values.statefulset.extraLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.statefulset.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ include "helmchart.fullname" . }}-sts
   {{- if not .Values.autoscaling.enabled }}

--- a/charts/helmchart/values.yaml
+++ b/charts/helmchart/values.yaml
@@ -5,6 +5,8 @@
 # -- Create deployment.yaml by default.
 deployment:
   enabled: true
+  annotations: {}
+    # -- Annotations to add on Deployment metadata.
 
 replicaCount: 1
   # -- Replica count used to configure the number of replica pods that should be deployed and maintained.
@@ -212,6 +214,8 @@ storageClass:
 statefulset:
   enabled: false
     # -- Set to true to deploy a StatefulSet instead of a Deployment
+  annotations: {}
+    # -- Annotations to add on StatefulSet metadata.
   image:
     repository: ""
       # -- Container image repository
@@ -254,6 +258,8 @@ statefulset:
 daemonset:
   enabled: false
     # -- Set to true to deploy a DaemonSet
+  annotations: {}
+    # -- Annotations to add on DaemonSet metadata.
   image: {}
     # -- DaemonSet image repository/pullPolicy/tag/digest
   secret:


### PR DESCRIPTION
### What

1. Added new values to support resource-level annotations on workload objects:
- deployment.annotations
- statefulset.annotations
- daemonset.annotations
2. Updated templates to render these values under each workload’s metadata.annotations:
- deployment.yaml
- statefulset.yaml
- daemonset.yaml
3. Added defaults and inline docs in values.yaml with empty maps to keep behavior backward-compatible.

### Why

- The chart already supported pod-level annotations (podAnnotations), but not annotations on the workload resources themselves.
- Many Kubernetes controllers/tools rely on workload metadata annotations (not pod template annotations), e.g. policy, governance, deployment automation, and platform integrations.
- This change gives consistent annotation support across all supported workload kinds (Deployment, StatefulSet, DaemonSet) without affecting existing installs unless values are explicitly set.